### PR TITLE
Allow named modules, but ignore their name

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,8 @@ function isexports(name) {
   return (name + "") === "exports";
 }
 
-self.define = function define(dependencies, factory) {
+self.define = function define(name, dependencies, factory) {
+  if (arguments.length < 3) factory = dependencies, dependencies = name;
   if (arguments.length < 2) factory = dependencies, dependencies = [];
   queue.push(some.call(dependencies, isexports) ? function(require) {
     var exports = {};


### PR DESCRIPTION
Currently, `d3-require` does not support named modules: If a named module is encountered, `d3-require` tries to call `require` on each character of the *name* string, as if it were an array of dependencies.

This would instead simply ignore the name argument of a named module, if it exists.

This allows usage with popular named AMD modules, such as jQuery and Underscore.js.