### PR TITLE
Record redirects.

### DIFF
--- a/test/test-dependency.html
+++ b/test/test-dependency.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script src="/dist/d3-require.js"></script>
+<script>
+
+d3.require("d3-graphviz").then(d3 => {
+  console.log(d3);
+});
+
+</script>


### PR DESCRIPTION
When a package.json is fetched, and this results in a redirect, we now store the promise under both the original URL and the redirected URL so that we can avoid fetching it again.
