### PR TITLE
Proposal: Add require.injectDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ The returned *require* function exposes the passed in *resolver* as [*require*.r
 <a href="#require_resolve" name="require_resolve">#</a> <i>require</i>.<b>resolve</b>(<i>name</i>[, <i>base</i>]) [<>](https://github.com/d3/d3-require/blob/master/index.js "Source")
 
 Returns a promise to the URL to load the module with the specified *name*. The *name* may also be specified as a relative path, in which case it is resolved relative to the specified *base* URL. If *base* is not specified, it defaults to the global [location](https://developer.mozilla.org/en-US/docs/Web/API/Window/location).
+
+<a href="#require_injectDependency" name="require_injectDependency">#</a> <i>require</i>.<b>injectDependency</b>(<i>name</i>, <i>module</i>) [<>](https://github.com/d3/d3-require/blob/master/index.js "Source")
+
+Resolves the name and injects *module* into the global cache. Create a new require function with a custom *resolver* to avoid fetching meta data.

--- a/index.js
+++ b/index.js
@@ -82,7 +82,14 @@ export function requireFrom(resolver) {
         : requireBase(name);
   }
 
+  function injectDependency(name, module) {
+    Promise.resolve(resolver(name, null)).then(function (url) {
+      modules.set(url, module);
+    });
+  }
+
   require.resolve = resolver;
+  require.injectDependency = injectDependency;
 
   return require;
 }

--- a/test/test-dependency-injection-module.js
+++ b/test/test-dependency-injection-module.js
@@ -1,0 +1,16 @@
+define(['react', 'glamor'], function (React, glamor) { 'use strict';
+
+  React = React && React.hasOwnProperty('default') ? React['default'] : React;
+
+  var Test = () => React.createElement(
+    "div",
+    glamor.css({
+      backgroundColor: 'purple',
+      color: 'white'
+    }),
+    "other side"
+  );
+
+  return Test;
+
+});

--- a/test/test-dependency-injection.html
+++ b/test/test-dependency-injection.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="https://unpkg.com/glamor@2.20.40/umd/index.js"></script>
+<script src="https://unpkg.com/react@16.4.0/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/react-dom@16.4.0/umd/react-dom.production.min.js"></script>
+<script src="/dist/d3-require.js"></script>
+<script>
+
+d3.require.injectDependency('react', React);
+d3.require.injectDependency('glamor', Glamor);
+d3.require("/test/test-dependency-injection-module.js").then(Test => {
+  ReactDOM.render(
+    React.createElement(
+      "div",
+      Glamor.css({
+        color: 'black'
+      }),
+      "Hello from the",
+      React.createElement(Test)
+    ), 
+    document.body
+  )
+  // two css rules in the global styleSheet, one from here, one form the module
+  const rules = Glamor.styleSheet.rules()
+  console.log(rules.length > 1, rules)
+});
+
+</script>


### PR DESCRIPTION
I plan to use `d3-require` within a bigger app to load extra, story specific components. The big app ships with certain modules webpacked in. In my case the big app provides `react`, `glamor` and a styleguide with base components.

A component that would be loaded in with `d3-require` would then look like this:
https://gist.github.com/tpreusse/4e1c8050cc6c8f4392a65ae98889810d

It would be nice to be able to inject those already present modules into `d3-require` and then access them from the lazy loaded components.

In order to accomplish this I had to add a new method to inject modules into the global `modules` map:

`require.injectDependency(name, module)`

I'm unsure about the exact naming and signature. And if one should pass in a module name or an url. This solution felt like it would fit the best into the current API surface. But it might not be obvious that a `injectDependency` call can trigger meta data fetches with the default resolver.