### PR TITLE
Add require.alias.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,16 @@ The returned *require* function exposes the passed in *resolver* as [*require*.r
 <a href="#require_resolve" name="require_resolve">#</a> <i>require</i>.<b>resolve</b>(<i>name</i>[, <i>base</i>]) [<>](https://github.com/d3/d3-require/blob/master/index.js "Source")
 
 Returns a promise to the URL to load the module with the specified *name*. The *name* may also be specified as a relative path, in which case it is resolved relative to the specified *base* URL. If *base* is not specified, it defaults to the global [location](https://developer.mozilla.org/en-US/docs/Web/API/Window/location).
+
+<a href="#require_alias" name="require_alias">#</a> <i>require</i>.<b>alias</b>(<i>aliases</i>) [<>](https://github.com/d3/d3-require/blob/master/index.js "Source")
+
+Returns a [require function](#require) with the specified *aliases*. For each key in the specified *aliases* object, any require of that key is substituted with the corresponding value. The values can be strings representing the name or URL of the module to load, or a literal non-string value for direct substitution. For example, if `React` and `ReactDOM` are already in-scope, you can say:
+
+```js
+d3.require.alias({
+  "react": React,
+  "react-dom": ReactDOM
+})("semiotic").then(Semiotic => {
+  console.log(Semiotic);
+});
+```

--- a/index.js
+++ b/index.js
@@ -80,9 +80,8 @@ export function requireFrom(resolver) {
   function requireAlias(aliases) {
     return requireFrom(function(name, base) {
       if (name in aliases) {
-        var alias = aliases[name];
-        if (typeof alias !== "string") return alias;
-        name = alias, base = null;
+        name = aliases[name], base = null;
+        if (typeof name !== "string") return name;
       }
       return resolver(name, base);
     });

--- a/index.js
+++ b/index.js
@@ -76,12 +76,19 @@ export function requireFrom(resolver) {
     return name => Promise.resolve(resolver(name, base)).then(requireAbsolute);
   }
 
+  function requireAlias(map) {
+    return requireFrom(function(name, base) {
+      return resolver(name in map ? map[name] : name, base);
+    });
+  }
+
   function require(name) {
     return arguments.length > 1
         ? Promise.all(map.call(arguments, requireBase)).then(merge)
         : requireBase(name);
   }
 
+  require.alias = requireAlias;
   require.resolve = resolver;
 
   return require;

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ export function requireFrom(resolver) {
   const requireBase = requireRelative(null);
 
   function requireAbsolute(url) {
+    if (typeof url !== "string") return url;
     let module = modules.get(url);
     if (!module) modules.set(url, module = new Promise((resolve, reject) => {
       const script = document.createElement("script");
@@ -78,7 +79,12 @@ export function requireFrom(resolver) {
 
   function requireAlias(map) {
     return requireFrom(function(name, base) {
-      return resolver(name in map ? map[name] : name, base);
+      if (name in map) {
+        var value = map[name];
+        if (typeof value !== "string") return value;
+        name = value, base = null;
+      }
+      return resolver(name, base);
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -77,12 +77,12 @@ export function requireFrom(resolver) {
     return name => Promise.resolve(resolver(name, base)).then(requireAbsolute);
   }
 
-  function requireAlias(map) {
+  function requireAlias(aliases) {
     return requireFrom(function(name, base) {
-      if (name in map) {
-        var value = map[name];
-        if (typeof value !== "string") return value;
-        name = value, base = null;
+      if (name in aliases) {
+        var alias = aliases[name];
+        if (typeof alias !== "string") return alias;
+        name = alias, base = null;
       }
       return resolver(name, base);
     });

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ export function requireFrom(resolver) {
   }
 
   function requireAlias(aliases) {
-    return requireFrom(function(name, base) {
+    return requireFrom((name, base) => {
       if (name in aliases) {
         name = aliases[name], base = null;
         if (typeof name !== "string") return name;


### PR DESCRIPTION
This brings over require.alias from [@observablehq/notebook-stdlib](https://github.com/observablehq/notebook-stdlib/blob/master/README.md#require_alias), and extends it to allow arbitrary values to be injected, rather than only allowing names to be aliased.

Supersedes #14.