### PR TITLE
Default to jsDelivr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A minimal, promise-based implementation to require [asynchronous module definiti
 
 * Named module definitions (*e.g.*, jQuery) are treated as anonymous modules.
 
-By default, [d3.require](#require) loads modules from [unpkg](https://unpkg.com/); the module *name* can be any package (or scoped package) name optionally followed by the at sign (@) and a semver range. For example, `d3.require("d3@5")` loads the highest version of [D3](https://d3js.org) 5.x. Relative paths and absolute URLs are also supported. You can change this behavior using [d3.requireFrom](#requireFrom).
+By default, [d3.require](#require) loads modules from [jsDelivr](https://jsdelivr.com/); the module *name* can be any package (or scoped package) name optionally followed by the at sign (@) and a semver range. For example, `d3.require("d3@5")` loads the highest version of [D3](https://d3js.org) 5.x. Relative paths and absolute URLs are also supported. You can change this behavior using [d3.requireFrom](#requireFrom).
 
 ## Installing
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const hasOwnProperty = queue.hasOwnProperty;
 const origin = "https://cdn.jsdelivr.net/npm/";
 const identifierRe = /^((?:@[^/@]+\/)?[^/@]+)(?:@([^/]+))?(?:\/(.*))?$/;
 const versionRe = /^\d+\.\d+\.\d+(-[\w-.+]+)?$/;
+const mains = ["unpkg", "jsdelivr", "browser", "main"];
 
 export class RequireError extends Error {
   constructor(message) {
@@ -15,8 +16,13 @@ export class RequireError extends Error {
 
 RequireError.prototype.name = RequireError.name;
 
-function string(value) {
-  return typeof value === "string" ? value : "";
+function main(meta) {
+  for (const key of mains) {
+    const value = meta[key];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
 }
 
 function parseIdentifier(identifier) {
@@ -53,7 +59,7 @@ async function resolve(name, base) {
   if (target.path && !/\.[^/]*$/.test(target.path)) target.path += ".js";
   if (target.path && target.version && versionRe.test(target.version)) return `${origin}${target.name}@${target.version}/${target.path}`;
   const meta = await resolveMeta(target);
-  return `${origin}${meta.name}@${meta.version}/${target.path || string(meta.unpkg) || string(meta.browser) || string(meta.main) || "index.js"}`;
+  return `${origin}${meta.name}@${meta.version}/${target.path || main(meta) || "index.js"}`;
 }
 
 export const require = requireFrom(resolve);

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const queue = [];
 const map = queue.map;
 const some = queue.some;
 const hasOwnProperty = queue.hasOwnProperty;
-const origin = "https://unpkg.com/";
+const origin = "https://cdn.jsdelivr.net/npm/";
 const identifierRe = /^((?:@[^/@]+\/)?[^/@]+)(?:@([^/]+))?(?:\/(.*))?$/;
 const versionRe = /^\d+\.\d+\.\d+(-[\w-.+]+)?$/;
 
@@ -50,6 +50,7 @@ async function resolve(name, base) {
     const meta = await resolveMeta(parseIdentifier(base.substring(origin.length)));
     target.version = meta.dependencies && meta.dependencies[target.name] || meta.peerDependencies && meta.peerDependencies[target.name];
   }
+  if (target.path && !/\.[^/]*$/.test(target.path)) target.path += ".js";
   if (target.path && target.version && versionRe.test(target.version)) return `${origin}${target.name}@${target.version}/${target.path}`;
   const meta = await resolveMeta(target);
   return `${origin}${meta.name}@${meta.version}/${target.path || string(meta.unpkg) || string(meta.browser) || string(meta.main) || "index.js"}`;


### PR DESCRIPTION
jsDelivr doesn’t support the default file extension, so explicitly added to resolve.

https://unpkg.com/viz.js/viz
https://unpkg.com/viz.js@2.1.2/viz.js
https://cdn.jsdelivr.net/npm/viz.js/viz (404)
https://cdn.jsdelivr.net/npm/viz.js@2.1.2/viz.js