### PR TITLE
Support AMD modules that declare 'module' as a dependency

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -134,21 +134,24 @@ function getter(object, name) {
   return () => object[name];
 }
 
-function isexports(name) {
-  return (name + "") === "exports";
+function isbuiltin(name) {
+  name = "" + name;
+  return name === "exports" || name === "module";
 }
 
 function define(name, dependencies, factory) {
   const n = arguments.length;
   if (n < 2) factory = name, dependencies = [];
   else if (n < 3) factory = dependencies, dependencies = typeof name === "string" ? [] : name;
-  queue.push(some.call(dependencies, isexports) ? require => {
+  queue.push(some.call(dependencies, isbuiltin) ? require => {
     const exports = {};
+    const module = { exports: exports };
     return Promise.all(map.call(dependencies, name => {
-      return isexports(name += "") ? exports : require(name);
+      name = name + "";
+      return  name === "exports" ? exports : name === "module" ? module : require(name);
     })).then(dependencies => {
       factory.apply(null, dependencies);
-      return exports;
+      return module.exports;
     });
   } : require => {
     return Promise.all(map.call(dependencies, require)).then(dependencies => {

--- a/src/index.js
+++ b/src/index.js
@@ -135,7 +135,7 @@ function getter(object, name) {
 }
 
 function isbuiltin(name) {
-  name = "" + name;
+  name = name + "";
   return name === "exports" || name === "module";
 }
 
@@ -145,10 +145,10 @@ function define(name, dependencies, factory) {
   else if (n < 3) factory = dependencies, dependencies = typeof name === "string" ? [] : name;
   queue.push(some.call(dependencies, isbuiltin) ? require => {
     const exports = {};
-    const module = { exports: exports };
+    const module = {exports};
     return Promise.all(map.call(dependencies, name => {
       name = name + "";
-      return  name === "exports" ? exports : name === "module" ? module : require(name);
+      return name === "exports" ? exports : name === "module" ? module : require(name);
     })).then(dependencies => {
       factory.apply(null, dependencies);
       return module.exports;

--- a/test/test-module.html
+++ b/test/test-module.html
@@ -6,4 +6,8 @@ d3.require("jszip/dist/jszip.js").then(jszip => {
   console.log(jszip);
 });
 
+d3.require("regression").then(jszip => {
+  console.log(jszip);
+});
+
 </script>


### PR DESCRIPTION
Fixes #25 - this allows a module to declare `module` as a dependency and modify or assign to `module.exports`.