### PR TITLE
SyntaxError: Identifier 'require' has already been declared

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ async function resolve(name, base) {
   return `${origin}${meta.name}@${meta.version}/${target.path || main(meta) || "index.js"}`;
 }
 
-export const require = requireFrom(resolve);
+export var require = requireFrom(resolve);
 
 export function requireFrom(resolver) {
   const cache = new Map;


### PR DESCRIPTION
In Node 10.16, attempting to declare `const require = ...` causes a SyntaxError:

> const require = function() {};
>       ^
> 
> SyntaxError: Identifier 'require' has already been declared
>     at Module._compile (internal/modules/cjs/loader.js:723:23)
>     at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
>     at Module.load (internal/modules/cjs/loader.js:653:32)
>     at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
>     at Function.Module._load (internal/modules/cjs/loader.js:585:3)
>     at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
>     at startup (internal/bootstrap/node.js:283:19)
>     at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)

Using a `var` for the export continues to work.