### PR TITLE
Specify the crossOrigin attribute when loading the module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,7 @@ export function requireFrom(resolver) {
         script.remove();
       };
       script.async = true;
+      script.crossOrigin = "anonymous";
       script.src = url;
       window.define = define;
       document.head.appendChild(script);


### PR DESCRIPTION
This allows scripts like React to properly listen to the `error` event, allowing better debugging.